### PR TITLE
Added webcitation.org and archive.is to the list of available archives

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 include =
     savepagenow/__init__.py
+    savepagenow/exceptions.py

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ http://web.archive.org/web/20161018203554/http://www.example.com/
 ```
 
 If a URL has been recently cached, archive.org may return the URL to that page rather
-than conduct a new capture. When that happens, the ``capture`` method will raise an ``CachedPage`` exception.
+than conduct a new capture. When that happens, the ``capture`` method will raise a ``CachedPage`` exception.
 
 This is likely happen if you request the same URL twice within a few seconds.
 

--- a/README.md
+++ b/README.md
@@ -32,3 +32,36 @@ See where it's stored.
 >>> print archive_url
 http://web.archive.org/web/20161018203554/http://www.example.com/
 ```
+
+If a URL has been recently cached, archive.org may return the URL to that page rather
+than conduct a new capture. When that happens, the ``capture`` method will raise an ``CachedPage`` exception.
+
+This is likely happen if you request the same URL twice within a few seconds.
+
+```python
+>>> savepagenow.capture("http://www.example.com/")
+'http://web.archive.org/web/20161019062637/http://www.example.com/'
+>>> savepagenow.capture("http://www.example.com/")
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "savepagenow/__init__.py", line 36, in capture
+    archive_url
+savepagenow.exceptions.CachedPage: archive.org returned a cached version of this page: http://web.archive.org/web/20161019062637/http://www.example.com/
+```
+
+You can craft your code to catch that exception yourself, or use the built-in ``capture_or_cache``
+method, which will return the URL provided by archive.org along with a boolean indicating if it
+is a fresh capture (True) or from the cache (False).
+
+```python
+>>> savepagenow.capture_or_cache("http://www.example.com/")
+('http://web.archive.org/web/20161019062832/http://www.example.com/', True)
+>>> savepagenow.capture_or_cache("http://www.example.com/")
+('http://web.archive.org/web/20161019062832/http://www.example.com/', False)
+```
+
+There's no accounting for taste but you could craft a line to handle that command like so:
+
+```python
+>>> url, captured = savepagenow.capture_or_cache("http://www.example.com/")
+```

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -38,45 +38,44 @@ def capture_web_archive_org(target_url):
     return archive_url
 
 
-def random_email():
-    """
-    Helper function for capture_webcitation
-
-    Webcitation requires you to include an email address when submitting
-
-    They do not check if it is valid
-    """
-    import random
-    from six.moves import range
-    alpha = "abcdefghijklmnopqrstuvwxyz"
-    choices = alpha + "0123456789"
-    domain = [".com", ".org", ".edu", ".co.uk", ".net"][random.randint(0, 4)]
-    text = []
-
-    # build the user portion of the email
-    for i in range(0, random.randint(2, 4)):
-        # need 2-4 individual chunks with length between 1-3 characters
-        for j in range(0, random.randint(1, 3)):
-            text.append(choices[random.randint(0, len(choices) - 1)])
-
-    text.append('@')
-
-    # build the email host
-    for i in range(0, random.randint(2, 3)):
-        for j in range(0, random.randint(1, 3)):
-            text.append(alpha[random.randint(0, len(alpha) - 1)])
-
-    text.append(domain)
-
-    return ''.join(text)
-
-
 def capture_webcitation(target_url):
     """
     Archives the provided URL using webcitation.org's submission form
 
     Returns the archive.is URL where the capture is stored.
     """
+
+    def random_email():
+        """
+        Helper function for capture_webcitation
+
+        Webcitation requires you to include an email address when submitting
+
+        They do not check if it is valid
+        """
+        import random
+        from six.moves import range
+        alpha = "abcdefghijklmnopqrstuvwxyz"
+        choices = alpha + "0123456789"
+        domain = [".com", ".org", ".edu", ".co.uk", ".net"][random.randint(0, 4)]
+        text = []
+
+        # build the user portion of the email
+        for i in range(0, random.randint(2, 4)):
+            # need 2-4 individual chunks with length between 1-3 characters
+            for j in range(0, random.randint(1, 3)):
+                text.append(choices[random.randint(0, len(choices) - 1)])
+
+        text.append('@')
+
+        # build the email host
+        for i in range(0, random.randint(2, 3)):
+            for j in range(0, random.randint(1, 3)):
+                text.append(alpha[random.randint(0, len(alpha) - 1)])
+
+        text.append(domain)
+
+        return ''.join(text)
 
     # Put together the URL that will save our request
     domain = "http://www.webcitation.org"

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -57,7 +57,7 @@ def capture_webcitation(target_url):
         from six.moves import range
         alpha = "abcdefghijklmnopqrstuvwxyz"
         choices = alpha + "0123456789"
-        domain = [".com", ".org", ".edu", ".co.uk", ".net"][random.randint(0, 4)]
+        domains = [".com", ".org", ".edu", ".co.uk", ".net"]
         text = []
 
         # build the user portion of the email
@@ -73,7 +73,7 @@ def capture_webcitation(target_url):
             for j in range(0, random.randint(1, 3)):
                 text.append(alpha[random.randint(0, len(alpha) - 1)])
 
-        text.append(domain)
+        text.append(domains[random.randint(0, 4)])
 
         return ''.join(text)
 

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -3,15 +3,14 @@
 import requests
 from .exceptions import CachedPage
 from six.moves.urllib.parse import urljoin
-
 __version__ = "0.0.5"
 
 
 def capture(
-        target_url,
-        archive="web.archive.org",
-        user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
-        accept_cache=False
+    target_url,
+    archive="web.archive.org",
+    user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
+    accept_cache=False
 ):
     if archive == "webcitation.org":
         return capture_webcitation(target_url, user_agent=user_agent)
@@ -20,18 +19,6 @@ def capture(
     else:
         return capture_web_archive_org(target_url, user_agent=user_agent,
                                        accept_cache=accept_cache)
-
-
-def capture_or_cache(
-        target_url,
-        user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
-):
-    try:
-        return capture(target_url, user_agent=user_agent,
-                       accept_cache=False), True
-    except CachedPage:
-        return capture(target_url, user_agent=user_agent,
-                       accept_cache=True), False
 
 
 def capture_web_archive_org(target_url, user_agent, accept_cache):
@@ -173,3 +160,13 @@ def capture_archive_is(target_url, user_agent):
 
     # the url to the memento is the first element in the list
     return mementos[0]
+
+
+def capture_or_cache(
+    target_url,
+    user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
+):
+    try:
+        return capture(target_url, user_agent=user_agent, accept_cache=False), True
+    except CachedPage:
+        return capture(target_url, user_agent=user_agent, accept_cache=True), False

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -1,6 +1,9 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
 import requests
 from .exceptions import CachedPage
 from six.moves.urllib.parse import urljoin
+__version__ = "0.0.4"
 
 
 def capture(

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -3,14 +3,38 @@
 import requests
 from .exceptions import CachedPage
 from six.moves.urllib.parse import urljoin
+
 __version__ = "0.0.5"
 
 
 def capture(
-    target_url,
-    user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
-    accept_cache=False
+        target_url,
+        archive="web.archive.org",
+        user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
+        accept_cache=False
 ):
+    if archive == "webcitation.org":
+        return capture_webcitation(target_url, user_agent=user_agent)
+    elif archive == "archive.is":
+        return capture_archive_is(target_url, user_agent=user_agent)
+    else:
+        return capture_web_archive_org(target_url, user_agent=user_agent,
+                                       accept_cache=accept_cache)
+
+
+def capture_or_cache(
+        target_url,
+        user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
+):
+    try:
+        return capture(target_url, user_agent=user_agent,
+                       accept_cache=False), True
+    except CachedPage:
+        return capture(target_url, user_agent=user_agent,
+                       accept_cache=True), False
+
+
+def capture_web_archive_org(target_url, user_agent, accept_cache):
     """
     Archives the provided URL using archive.org's Wayback Machine.
 
@@ -43,11 +67,109 @@ def capture(
     return archive_url
 
 
-def capture_or_cache(
-    target_url,
-    user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
-):
-    try:
-        return capture(target_url, user_agent=user_agent, accept_cache=False), True
-    except CachedPage:
-        return capture(target_url, user_agent=user_agent, accept_cache=True), False
+def capture_webcitation(target_url, user_agent):
+    """
+    Archives the provided URL using webcitation.org's submission form
+
+    Returns the archive.is URL where the capture is stored.
+    """
+
+    def random_email():
+        """
+        Helper function for capture_webcitation
+
+        Webcitation requires you to include an email address when submitting
+
+        They do not check if it is valid
+        """
+        import random
+        from six.moves import range
+        alpha = "abcdefghijklmnopqrstuvwxyz"
+        choices = alpha + "0123456789"
+        domains = [".com", ".org", ".edu", ".co.uk", ".net"]
+        text = []
+
+        # build the user portion of the email
+        for i in range(0, random.randint(2, 4)):
+            # need 2-4 individual chunks with length between 1-3 characters
+            for j in range(0, random.randint(1, 3)):
+                text.append(choices[random.randint(0, len(choices) - 1)])
+
+        text.append('@')
+
+        # build the email host
+        for i in range(0, random.randint(2, 3)):
+            for j in range(0, random.randint(1, 3)):
+                text.append(alpha[random.randint(0, len(alpha) - 1)])
+
+        text.append(domains[random.randint(0, 4)])
+
+        return ''.join(text)
+
+    # Put together the URL that will save our request
+    domain = "http://www.webcitation.org"
+    save_url = urljoin(domain, "/archive.php")
+
+    # generate the random email
+    email = random_email()
+
+    # Send the capture request to webcitation.org
+    headers = {
+        'User-Agent': user_agent,
+    }
+    data = {"email": email, "url": target_url}
+    response = requests.post(save_url, headers=headers, data=data)
+
+    # build the regular expression to find
+    # the location of the archived resource
+    import re
+    archived_location_regex = re.compile(r"""(          # begin capture group
+                                       [A-Za-z]{4,5}:// # matches http(s)://
+                                       [a-z]{3}\.       # matches www.
+                                       [a-z]{11}        # matches webcitation
+                                       \.[a-z]{3}/      # matches .org/
+                                       [a-zA-z0-9]{9}   # matches 9 character
+                                                        # archived resource
+                                                        # unique identifier
+                                       )                # end capture group
+                                       """, re.X)
+
+    # search through the returned html page for the location
+    # to the archived resource
+    # when found, the url-m is contained in group 0 of the returned MatchObject
+    # see https://docs.python.org/3/library/re.html#re.regex.search
+    archive_url = archived_location_regex.search(response.text).group(0)
+
+    return archive_url
+
+
+def capture_archive_is(target_url, user_agent):
+    """
+    Archives the provided URL using archive.is's submission form
+
+    Returns the archive.is URL where the capture is stored.
+    """
+    # Put together the URL that will save our request
+    domain = "http://archive.is"
+    save_url = urljoin(domain, "/submit/")
+
+    # Send the capture request to archive.is
+    headers = {
+        'User-Agent': user_agent,
+    }
+    data = {"coo": '', "url": target_url}
+    response = requests.post(save_url, headers=headers, data=data)
+
+    # archive.is returns a link format timemap in the header field link
+    # but if it was the first time archive.is has archived the uri-r
+    # or for some other reason unknown at this time
+    # this information will not be present so resort to searching the
+    # returned html page
+    import re
+    memento_re = re.compile('"(http(?:s)?://archive\.is/(?:[0-9]{14}/(?:\b)?)?'
+                            '[-a-zA-Z0-9@:%_+.~#?&/=]+)"',
+                            re.IGNORECASE | re.MULTILINE)
+    mementos = memento_re.findall(response.text)
+
+    # the url to the memento is the first element in the list
+    return mementos[0]

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -6,7 +6,7 @@ from six.moves.urllib.parse import urljoin
 def capture(
     target_url,
     user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
-    return_cache=False
+    accept_cache=False
 ):
     """
     Archives the provided URL using archive.org's Wayback Machine.
@@ -31,21 +31,20 @@ def capture(
     # Determine if the response was cached
     cached = response.headers['X-Page-Cache'] == 'HIT'
     if cached:
-        if return_cache:
-            pass
-        else:
-            raise CachedPage("archive.org returned a cached version of this page")
+        if not accept_cache:
+            raise CachedPage("archive.org returned a cached version of this page: {}".format(
+                archive_url
+            ))
 
     # Return that
     return archive_url
 
 
-def capture_or_return_cache(
+def capture_or_cache(
     target_url,
     user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
 ):
-    kwargs = dict(user_agent=user_agent, return_cache=True)
     try:
-        return capture(target_url, **kwargs), False
+        return capture(target_url, user_agent=user_agent, accept_cache=False), True
     except CachedPage:
-        return capture(target_url, **kwargs), True
+        return capture(target_url, user_agent=user_agent, accept_cache=True), False

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -170,13 +170,3 @@ def capture_or_cache(
         return capture(target_url, user_agent=user_agent, accept_cache=False), True
     except CachedPage:
         return capture(target_url, user_agent=user_agent, accept_cache=True), False
-
-
-def capture_or_cache(
-    target_url,
-    user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
-):
-    try:
-        return capture(target_url, user_agent=user_agent, accept_cache=False), True
-    except CachedPage:
-        return capture(target_url, user_agent=user_agent, accept_cache=True), False

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -1,10 +1,12 @@
 import requests
+from .exceptions import CachedPage
 from six.moves.urllib.parse import urljoin
 
 
 def capture(
     target_url,
-    user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
+    user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
+    return_cache=False
 ):
     """
     Archives the provided URL using archive.org's Wayback Machine.
@@ -29,7 +31,21 @@ def capture(
     # Determine if the response was cached
     cached = response.headers['X-Page-Cache'] == 'HIT'
     if cached:
-        print("Cached URL returned")
+        if return_cache:
+            pass
+        else:
+            raise CachedPage("archive.org returned a cached version of this page")
 
     # Return that
     return archive_url
+
+
+def capture_or_return_cache(
+    target_url,
+    user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
+):
+    kwargs = dict(user_agent=user_agent, return_cache=True)
+    try:
+        return capture(target_url, **kwargs), False
+    except CachedPage:
+        return capture(target_url, **kwargs), True

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -3,7 +3,7 @@
 import requests
 from .exceptions import CachedPage
 from six.moves.urllib.parse import urljoin
-__version__ = "0.0.4"
+__version__ = "0.0.5"
 
 
 def capture(

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -2,7 +2,16 @@ import requests
 from six.moves.urllib.parse import urljoin
 
 
-def capture(target_url):
+def capture(target_url, archive='web.archive.org'):
+    if archive == 'webcitation.org':
+        return capture_webcitation(target_url)
+    elif archive == 'archive.is':
+        return capture_archive_is(target_url)
+    else:
+        return capture_web_archive_org(target_url)
+
+
+def capture_web_archive_org(target_url):
     """
     Archives the provided URL using archive.org's Wayback Machine.
 
@@ -27,3 +36,106 @@ def capture(target_url):
 
     # Return that
     return archive_url
+
+
+def random_email():
+    """
+    Helper function for capture_webcitation
+
+    Webcitation requires you to include an email address when submitting
+
+    They do not check if it is valid
+    """
+    import random
+    from six.moves import range
+    alpha = "abcdefghijklmnopqrstuvwxyz"
+    choices = alpha + "0123456789"
+    domain = [".com", ".org", ".edu", ".co.uk", ".net"][random.randint(0, 4)]
+    text = []
+
+    # build the user portion of the email
+    for i in range(0, random.randint(2, 4)):
+        # need 2-4 individual chunks with length between 1-3 characters
+        for j in range(0, random.randint(1, 3)):
+            text.append(choices[random.randint(0, len(choices) - 1)])
+
+    text.append('@')
+
+    # build the email host
+    for i in range(0, random.randint(2, 3)):
+        for j in range(0, random.randint(1, 3)):
+            text.append(alpha[random.randint(0, len(alpha) - 1)])
+
+    text.append(domain)
+
+    return ''.join(text)
+
+
+def capture_webcitation(target_url):
+    """
+    Archives the provided URL using webcitation.org's submission form
+
+    Returns the archive.is URL where the capture is stored.
+    """
+
+    # Put together the URL that will save our request
+    domain = "http://www.webcitation.org"
+    save_url = urljoin(domain, "/archive.php")
+
+    # generate the random email
+    email = random_email()
+
+    # Send the capture request to webcitation.org
+    data = {"email": email, "url": target_url}
+    response = requests.post(save_url, data=data)
+
+    # build the regular expression to find
+    # the location of the archived resource
+    import re
+    archived_location_regex = re.compile(r"""(          # begin capture group
+                                       [A-Za-z]{4,5}:// # matches http(s)://
+                                       [a-z]{3}\.       # matches www.
+                                       [a-z]{11}        # matches webcitation
+                                       \.[a-z]{3}/      # matches .org/
+                                       [a-zA-z0-9]{9}   # matches 9 character
+                                                        # archived resource
+                                                        # unique identifier
+                                       )                # end capture group
+                                       """, re.X)
+
+    # search through the returned html page for the location
+    # to the archived resource
+    # when found, the url-m is contained in group 0 of the returned MatchObject
+    # see https://docs.python.org/3/library/re.html#re.regex.search
+    archive_url = archived_location_regex.search(response.text).group(0)
+
+    return archive_url
+
+
+def capture_archive_is(target_url):
+    """
+    Archives the provided URL using archive.is's submission form
+
+    Returns the archive.is URL where the capture is stored.
+    """
+    # Put together the URL that will save our request
+    domain = "http://archive.is"
+    save_url = urljoin(domain, "/submit/")
+
+    # Send the capture request to archive.is
+    data = {"coo": '', "url": target_url}
+    response = requests.post(save_url, data=data)
+
+    # archive.is returns a link format timemap in the header field link
+    # but if it was the first time archive.is has archived the uri-r
+    # or for some other reason unknown at this time
+    # this information will not be present so resort to searching the
+    # returned html page
+    import re
+    memento_re = re.compile('"(http(?:s)?://archive\.is/(?:[0-9]{14}/(?:\b)?)?'
+                            '[-a-zA-Z0-9@:%_+.~#?&/=]+)"',
+                            re.IGNORECASE | re.MULTILINE)
+    mementos = memento_re.findall(response.text)
+
+    # the url to the memento is the first element in the list
+    return mementos[0]

--- a/savepagenow/exceptions.py
+++ b/savepagenow/exceptions.py
@@ -1,0 +1,6 @@
+class CachedPage(Exception):
+    """
+    This error is raised when archive.org declines to make a new capture
+    and instead returns the cached version of most recent archive.
+    """
+    pass

--- a/savepagenow/exceptions.py
+++ b/savepagenow/exceptions.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
+class CachedPage(Exception):
+    """
+    This error is raised when archive.org declines to make a new capture
+    and instead returns the cached version of most recent archive.
+    """
+    pass

--- a/savepagenow/exceptions.py
+++ b/savepagenow/exceptions.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+
 class CachedPage(Exception):
     """
     This error is raised when archive.org declines to make a new capture

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='savepagenow',
-    version='0.0.2',
+    version='0.0.3',
     description='A simple Python wrapper for archive.org\'s "Save Page Now" capturing service.',
     author='Ben Welsh',
     author_email='ben.welsh@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='savepagenow',
-    version='0.0.4',
+    version='0.0.5',
     description='A simple Python wrapper for archive.org\'s "Save Page Now" capturing service.',
     author='Ben Welsh',
     author_email='ben.welsh@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='savepagenow',
-    version='0.0.3',
+    version='0.0.4',
     description='A simple Python wrapper for archive.org\'s "Save Page Now" capturing service.',
     author='Ben Welsh',
     author_email='ben.welsh@gmail.com',

--- a/test.py
+++ b/test.py
@@ -7,10 +7,10 @@ import savepagenow
 class CaptureTest(unittest.TestCase):
 
     def test_capture(self):
-        archive_url_1 = savepagenow.capture("http://www.example.com/")
+        archive_url_1, c1 = savepagenow.capture_or_return_cache("http://www.example.com/")
         self.assertTrue(archive_url_1.startswith("http://web.archive.org/"))
 
-        archive_url_2 = savepagenow.capture(
+        archive_url_2, c2 = savepagenow.capture_or_return_cache(
             "http://www.example.com/",
             user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
         )

--- a/test.py
+++ b/test.py
@@ -5,7 +5,6 @@ import savepagenow
 
 
 class CaptureTest(unittest.TestCase):
-
     def test_capture(self):
         archive_url_1 = savepagenow.capture("http://www.example.com/")
         self.assertTrue(archive_url_1.startswith("http://web.archive.org/"))
@@ -16,6 +15,33 @@ class CaptureTest(unittest.TestCase):
         )
         self.assertTrue(archive_url_2.startswith("http://web.archive.org/"))
         self.assertEquals(archive_url_1, archive_url_2)
+
+    def test_capture_additional_archives(self):
+        # webcitation and archive.is generate unique identifiers
+        # e.g 6lNs1rSP8 != 6lNs26aSl per archive request
+        # testing two requests for the same resource to produce
+        # the same url would always fail
+        archive_url_1 = savepagenow.capture("http://www.example.com/",
+                                            archive='webcitation.org')
+        archive_url_2 = savepagenow.capture(
+            "http://www.example.com/",
+            archive='webcitation.org',
+            user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
+        )
+
+        self.assertTrue(archive_url_1.startswith("http://www.webcitation.org"))
+        self.assertTrue(archive_url_2.startswith("http://www.webcitation.org"))
+
+        archive_url_1 = savepagenow.capture("http://www.example.com/",
+                                            archive='archive.is')
+        archive_url_2 = savepagenow.capture(
+            "http://www.example.com/",
+            archive='archive.is',
+            user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
+        )
+
+        self.assertTrue(archive_url_1.startswith("http://archive.is"))
+        self.assertTrue(archive_url_2.startswith("http://archive.is"))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -5,10 +5,15 @@ import savepagenow
 
 
 class CaptureTest(unittest.TestCase):
-
     def test_attr(self):
         archive_url = savepagenow.capture("http://www.example.com/")
         self.assertTrue(archive_url.startswith("http://web.archive.org/"))
+        archive_url = savepagenow.capture("http://www.example.com/",
+                                          archive='webcitation.org')
+        self.assertTrue(archive_url.startswith("http://www.webcitation.org"))
+        archive_url = savepagenow.capture("http://www.example.com/",
+                                          archive='archive.is')
+        self.assertTrue(archive_url.startswith("http://archive.is"))
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -7,10 +7,10 @@ import savepagenow
 class CaptureTest(unittest.TestCase):
 
     def test_capture(self):
-        archive_url_1, c1 = savepagenow.capture_or_return_cache("http://www.example.com/")
+        archive_url_1, c1 = savepagenow.capture_or_cache("http://www.example.com/")
         self.assertTrue(archive_url_1.startswith("http://web.archive.org/"))
 
-        archive_url_2, c2 = savepagenow.capture_or_return_cache(
+        archive_url_2, c2 = savepagenow.capture_or_cache(
             "http://www.example.com/",
             user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
         )


### PR DESCRIPTION
This PR adds `http://www.webcitation.org` and `http://archive.is` to the archives available through this library.
### **init**.py

The additional archives are made available with minimal changes to current API implementation.
`def capture(target_url)` has been modified with the argument `archive='web.archive.org'` 

Providing the default value of `web.archive.org` allows existing methods 
depending on it to function without change 
  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;See tests.py lines 9 and 10

 `http://www.webcitation.org` is used when capture is called with `archive='webcitation.org'`, `caputure(<uri-r>,'webcitation.org')`

Likewise `http://archive.is` is used when capture is called 
with  `archive='archive.is'`, `caputure(<uri-r>,'archive.is')`

Each archive put into its own method and are available alongside capture when importing this library
The original implementation of `capture` is found in the method `def capture_web_archive_org(target_url)`

Both `def capture_webcitation(target_url)` and `def capture_archive_is(target_url)` 
follow the coding conventions of the original implementation of `def capture(target_url)`

`def capture_webcitation(target_url)`  utilizes an inner helper method `def random_email()`
 in order to meet the submission requirements for  `http://www.webcitation.org`

This helper method was also necessary when utilizing `http://www.webcitation.org` for archiving was implemented in [Mink](https://github.com/machawk1/Mink/blob/88f92e6d58d6f49196b97d7eba81447264ed5521/mink-plugin/js/displayMinkUI.js#L199)

The second commit of this PR https://github.com/pastpages/savepagenow/commit/fd0b866593f81a25457008be646ea5e3e3d5739f moved the helper from the global scope of this library to 
the inner scope of `def capture_webcitation(target_url)`
### tests.py

`tests.py` was modified to include tests for the additional archives

Below is the results of running the unit tests.
![savepagenowunittestpass](https://cloud.githubusercontent.com/assets/8648317/19507245/abc1bf4c-959f-11e6-9f78-94daab204b8f.png)

This PR is in full compliance with [PEP8 ](https://www.python.org/dev/peps/pep-0008/) as seen below
![pep8compliance](https://cloud.githubusercontent.com/assets/8648317/19507237/a005c248-959f-11e6-9e45-a46e637baf25.png)
