### PR TITLE
versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ See where it's stored.
 http://web.archive.org/web/20161018203554/http://www.example.com/
 ```
 
-If a URL has been recently cached, archive.org may return the URL to that page rather
-than conduct a new capture. When that happens, the ``capture`` method will raise a ``CachedPage`` exception.
+If a URL has been recently cached, archive.org may return the URL to that page
+rather than conduct a new capture. When that happens, the ``capture`` method
+will raise a ``CachedPage`` exception.
 
 This is likely happen if you request the same URL twice within a few seconds.
 
@@ -66,6 +67,31 @@ There's no accounting for taste but you could craft a line to handle that comman
 >>> url, captured = savepagenow.capture_or_cache("http://www.example.com/")
 ```
 
+If you want to see the already existing versions of a URL use get_versions which
+will return an iterator that you can use to safely page through the results:
+
+```python
+>>> for url in savepagenow.get_versions('https://www.pastpages.org', limit=10):
+...     print(url)
+... 
+https://web.archive.org/web/20120520115524/http://www.pastpages.org/
+https://web.archive.org/web/20120520115525/http://www.pastpages.org/
+https://web.archive.org/web/20120526045236/http://www.pastpages.org/
+https://web.archive.org/web/20120618220918/http://www.pastpages.org/
+https://web.archive.org/web/20120620013925/http://www.pastpages.org/
+https://web.archive.org/web/20121108093222/http://www.pastpages.org/
+https://web.archive.org/web/20130316162733/http://www.pastpages.org/
+https://web.archive.org/web/20130616072503/http://www.pastpages.org/
+https://web.archive.org/web/20130619201440/http://www.pastpages.org/
+https://web.archive.org/web/20130820141425/http://www.pastpages.org/
+```
+
+If you don't use the ``limit`` parameter then the iterator will page through all
+archived URLs. The ``chunk_limit`` will control how many URLs are requested at a
+time from the Internet Archive's [CDX
+API](https://github.com/internetarchive/wayback/blob/master/wayback-cdx-server/README.md).
+If no value is supplied it will default to 1000, and has a maximum of 150000.
+
 ### Command-line usage
 
 The Python library is also installed as a command-line interface. You can run it from your terminal like so:
@@ -74,13 +100,28 @@ The Python library is also installed as a command-line interface. You can run it
 $ savepagenow http://www.example.com/
 ```
 
+```bash  
+$ savepagenow --versions --limit 10 http://www.pastpages.org/
+https://web.archive.org/web/20120520115524/http://www.pastpages.org/
+https://web.archive.org/web/20120520115525/http://www.pastpages.org/
+https://web.archive.org/web/20120526045236/http://www.pastpages.org/
+https://web.archive.org/web/20120618220918/http://www.pastpages.org/
+https://web.archive.org/web/20120620013925/http://www.pastpages.org/
+https://web.archive.org/web/20121108093222/http://www.pastpages.org/
+https://web.archive.org/web/20130316162733/http://www.pastpages.org/
+https://web.archive.org/web/20130616072503/http://www.pastpages.org/
+https://web.archive.org/web/20130619201440/http://www.pastpages.org/
+https://web.archive.org/web/20130820141425/http://www.pastpages.org/
+...
+```
+
 The command has the same options as the Python API, which you can learn about from its help output.
 
 ```bash
 $ savepagenow --help
 Usage: savepagenow [OPTIONS] URL
 
-  Archives the provided URL using the archive.org Wayback Machine.
+  Archives the provided URL using archive.org Wayback Machine.
 
   Raises a CachedPage exception if archive.org declines to conduct a new
   capture and returns a previous snapshot instead.
@@ -88,7 +129,10 @@ Usage: savepagenow [OPTIONS] URL
 Options:
   -ua, --user-agent TEXT  User-Agent header for the web request
   -c, --accept-cache      Accept and return cached URL
-  --help                  Show this message and exit.
+  -v, --versions          Print archived versions of URL
+  -l, --limit INTEGER     Limit number of archive URLs to return. The default
+                          of 0 is unlimited.
+  --help                  Show this message and exit.k
 ```
 
 ### Customizing the user agent

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from .api import capture, capture_or_cache, CachedPage, BlockedByRobots
+from .api import capture, capture_or_cache, get_versions, CachedPage, BlockedByRobots
 
 
 __version__ = "0.0.8"
@@ -9,4 +9,5 @@ __all__ = (
     'capture',
     'capture_or_cache',
     'CachedPage',
+    'get_versions',
 )

--- a/test.py
+++ b/test.py
@@ -26,5 +26,26 @@ class CaptureTest(unittest.TestCase):
     #         savepagenow.capture("http://www.archive.is/faq.html")
 
 
+class VersionsTest(unittest.TestCase):
+
+    def test_versions(self):
+        versions = savepagenow.get_versions('https://nytimes.com')
+        version = next(versions)
+        self.assertTrue(version.startswith('https://web.archive.org/'))
+
+    def test_versions_limit(self):
+        count = 0
+        versions = savepagenow.get_versions('http://nytimes.com', limit=1111)
+        self.assertEqual(len(list(versions)), 1111)
+
+    def test_versions_paging(self):
+        count = 0
+        for url in savepagenow.get_versions('https://nytimes.com', chunk_limit=10):
+            count += 1
+            if count > 10:
+                break
+        self.assertTrue(count > 10)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR adds a new function `savepagenow.get_versions` which allows you to iterate through archived versions for a URL. It uses the [Internet Archive's CDX API](https://github.com/internetarchive/wayback/tree/master/wayback-cdx-server) to determine them, and will safely page through all the results.

```python
for url in savepagenow.get_versions('https://www.pastpages.org'):
    print(url)
```

Use the limit parameter to limit the total number URLs that the iterator returns. You can also control the total number of URLs that are requested at a time from the CDX API using the chunk_limit parameter.

The CLI exposes this functionality with the --versions option, e.g.

% savepagenow --versions http://www.pastpages.org/
https://web.archive.org/web/20120520115524/http://www.pastpages.org/
https://web.archive.org/web/20120520115525/http://www.pastpages.org/
https://web.archive.org/web/20120526045236/http://www.pastpages.org/
https://web.archive.org/web/20120618220918/http://www.pastpages.org/
https://web.archive.org/web/20120620013925/http://www.pastpages.org/
https://web.archive.org/web/20121108093222/http://www.pastpages.org/
https://web.archive.org/web/20130316162733/http://www.pastpages.org/
https://web.archive.org/web/20130616072503/http://www.pastpages.org/
https://web.archive.org/web/20130619201440/http://www.pastpages.org/
https://web.archive.org/web/20130820141425/http://www.pastpages.org/
...
```