### PR TITLE
Updated test

### DIFF
--- a/test.py
+++ b/test.py
@@ -9,7 +9,7 @@ class CaptureTest(unittest.TestCase):
 
     def test_capture(self):
         random_number = random.choice(range(0, 1000))
-        url = "http://www.example.com/my-random-page-{}".format(random_number)
+        url = "http://www.example.com/?q={}".format(random_number)
         archive_url_1, c1 = savepagenow.capture_or_cache(url)
         self.assertTrue(archive_url_1.startswith("https://web.archive.org/"))
 

--- a/test.py
+++ b/test.py
@@ -19,7 +19,6 @@ class CaptureTest(unittest.TestCase):
             user_agent="savepagenow (https://github.com/pastpages/savepagenow)"
         )
         self.assertTrue(archive_url_2.startswith("https://web.archive.org/"))
-        self.assertEqual(archive_url_1, archive_url_2)
 
     # def test_robots_error(self):
     #     with self.assertRaises(savepagenow.BlockedByRobots):


### PR DESCRIPTION
This commit removes a test that was failing because SPN API now returns distinct URLs. Perhaps this change came about when the SPN service was substantially updated last October?

https://blog.archive.org/2019/10/23/the-wayback-machines-save-page-now-is-new-and-improved/