### PR TITLE
Add support for Save Page Now v2 API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 dist/
 build/
 .coverage
+.vscode

--- a/savepagenow/__init__.py
+++ b/savepagenow/__init__.py
@@ -1,6 +1,14 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from .api import capture, capture_or_cache, CachedPage, BlockedByRobots
+from .api import (
+    capture,
+    capture_or_cache,
+    capture_v2,
+    queue_capture_v2,
+    get_status_v2,
+    CachedPage,
+    BlockedByRobots
+)
 
 
 __version__ = "1.0.1"
@@ -9,5 +17,8 @@ __all__ = (
     'BlockedByRobots',
     'capture',
     'capture_or_cache',
+    'capture_v2',
+    'queue_capture_v2',
+    'get_status_v2',
     'CachedPage'
 )

--- a/savepagenow/api.py
+++ b/savepagenow/api.py
@@ -1,19 +1,27 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 import click
+from collections.abc import Sequence
+from datetime import timedelta
+from os import getenv
 import requests
 from .exceptions import (
     CachedPage,
     WaybackRuntimeError,
+    BlockedUrl,
     BlockedByRobots
 )
 from urllib.parse import urljoin
 from requests.utils import parse_header_links
+import time
+
+
+USER_AGENT = "savepagenow (https://github.com/pastpages/savepagenow)"
 
 
 def capture(
     target_url,
-    user_agent="savepagenow (https://github.com/pastpages/savepagenow)",
+    user_agent=USER_AGENT,
     accept_cache=False
 ):
     """
@@ -74,7 +82,7 @@ def capture(
         # .. and we're not allowing that
         if not accept_cache:
             # ... throw an error
-            msg = "archive.org returned a cache of this page: {}".format(archive_url)
+            msg = f'archive.org returned a cache of this page: {archive_url}'
             raise CachedPage(msg)
 
     # Finally, return the archived URL
@@ -100,6 +108,345 @@ def capture_or_cache(
         return capture(target_url, user_agent=user_agent, accept_cache=False), True
     except CachedPage:
         return capture(target_url, user_agent=user_agent, accept_cache=True), False
+
+
+def queue_capture_v2(
+    target_url,
+    user_agent=USER_AGENT,
+    accept_cache=False,
+    s3_access_key=None,
+    s3_secret_key=None,
+    capture_all=False,
+    capture_outlinks=False,
+    capture_screenshot=False,
+    force_get=False,
+    skip_first_archive=False,
+    if_not_archived_within=None,
+    outlinks_availability=False,
+    email_result=False,
+    js_behavior_timeout=None,
+    capture_cookie=None,
+    target_username=None,
+    target_password=None
+):
+    """
+    Enqueue a request to capture the provided URL using archive.org's advanced
+    API. This returns information about the capture job that was queued; to get
+    the results, call ``get_status_v2``.
+
+    Returns a dict with the ID of the enqueued capture job and the requested
+    URL.
+
+    Raises a CachedPage exception if archive.org declines to conduct a new
+    capture and returns a previous snapshot instead.
+
+    To silence that exception, pass into True to the ``accept_cache`` keyword
+    argument.
+    """
+    data = {
+        'url': target_url,
+        'capture_all': int(capture_all),
+        'capture_outlinks': int(capture_outlinks),
+        'capture_screenshot': int(capture_screenshot),
+        'force_get': int(force_get),
+        'skip_first_archive': int(skip_first_archive),
+        'outlinks_availability': int(outlinks_availability),
+        'email_result': int(email_result),
+    }
+
+    if if_not_archived_within:
+        if isinstance(if_not_archived_within, Sequence):
+            timeframe = if_not_archived_within
+        else:
+            timeframe = [if_not_archived_within]
+        for index, value in enumerate(timeframe):
+            if isinstance(value, timedelta):
+                timeframe[index] = str(value.total_seconds())
+            else:
+                timeframe[index] = str(value)
+        data['if_not_archived_within'] = ','.join(timeframe)
+
+    if js_behavior_timeout is not None:
+        if not isinstance(js_behavior_timeout, (float, int)):
+            raise TypeError('js_behavior_timeout must be a number >= 0')
+        elif js_behavior_timeout < 0:
+            raise ValueError('js_behavior_timeout must be >= 0')
+        data['js_behavior_timeout'] = js_behavior_timeout
+
+    if capture_cookie:
+        data['capture_cookie'] = capture_cookie
+
+    if target_username:
+        data['target_username'] = target_username
+    if target_password:
+        data['target_password'] = target_password
+
+    response = requests.post('https://web.archive.org/save', data=data, headers={
+        'Accept': 'application/json',
+        'Authorization': get_authorization(s3_access_key, s3_secret_key),
+        'User-Agent': user_agent,
+    })
+
+    result = response.json()
+    if result.get('status') == 'error':
+        raise parse_api_error(result)
+    # If the page was recently captured and a new job was not started, the API
+    # returns a normal job info object with an added "message" property.
+    elif 'message' in result and not accept_cache:
+        # TODO: Modify CachedPage to accept extra info
+        error = CachedPage(f'{result["message"]} Capture job: {result["job_id"]}')
+        error.job_id = result['job_id']
+        error.url = result['url']
+        raise error
+
+    return result
+
+
+def get_status_v2(
+    job_id,
+    user_agent=USER_AGENT,
+    s3_access_key=None,
+    s3_secret_key=None
+):
+    """
+    Get the status of a capture job that was queued using ``queue_capture_v2``.
+    If the job is complete, this will return details about the results.
+
+    This returns a dict with the status and other details of the job. If a job
+    is still pending, the ``status`` property will be ``"pending"``. If a job
+    is complete, the ``status`` property will be ``"complete"`` and additional
+    details about the result will be included in the dict.
+
+    If a job failed, this will raise an exception representing the error as a
+    subclass of ``savepagenow.WaybackRuntimeError`` or
+    ``savepagenow.BlockedUrl``.
+    """
+    response = requests.get(
+        # Unfortunately, there's a caching proxy in front of this API, even
+        # though it's meant for polling. Tack the current time onto each
+        # to break the cache.
+        f'https://web.archive.org/save/status/{job_id}?dont-cache={time.time()}',
+        headers={
+            'Accept': 'application/json',
+            'Authorization': get_authorization(s3_access_key, s3_secret_key),
+            'User-Agent': user_agent,
+        }
+    )
+
+    result = response.json()
+    if 'error' in result:
+        raise parse_api_error(result)
+
+    return result
+
+
+def capture_v2(
+    target_url,
+    user_agent=USER_AGENT,
+    accept_cache=False,
+    s3_access_key=None,
+    s3_secret_key=None,
+    capture_all=False,
+    capture_outlinks=False,
+    capture_screenshot=False,
+    force_get=False,
+    skip_first_archive=False,
+    if_not_archived_within=None,
+    outlinks_availability=False,
+    email_result=False,
+    js_behavior_timeout=None,
+    capture_cookie=None,
+    target_username=None,
+    target_password=None,
+    status_interval=1
+):
+    """
+    Archives the provided URL using archive.org's advanced API. This method
+    requires authentication, but allows for much more fine-grained control over
+    the capture process.
+
+    Authentication is performed using the "S3-like" keys that can be found for
+    your account at: https://archive.org/account/s3.php. Provide them using the
+    ``s3_access_key`` and ``s3_secret_key`` arguments or via the
+    ``IAS3_ACCESS_KEY`` and ``IAS3_SECRET_KEY`` environment variables.
+
+    This returns a dict with details of the job. If a job.
+
+    Raises a CachedPage exception if archive.org declines to conduct a new
+    capture and returns a previous snapshot instead. To silence that exception,
+    pass into True to the ``accept_cache`` keyword argument.
+
+    This may also raise a WaybackRuntimeError with more details if the capture
+    fails for other reasons.
+
+    For more complete details of the advanced API, check the documentation at:
+    https://docs.google.com/document/d/1Nsv52MvSjbLb2PCpHlat0gkzw0EvtSgpKHu4mk0MnrA
+
+    Parameters
+    ----------
+    - ``target_url`` is the URL to capture. This is the only required parameter.
+    - ``user_agent`` is a custom user agent to use when communitcating with the
+      Internet Archive.
+    - ``accept_cache`` controls whether a ``CachedPage`` exception is raised if
+      the page was already captured recently.
+    - ``s3_access_key`` The S3-like access key to log into the Internet Archive
+      with. This can also be set via the `IAS3_ACCESS_KEY` environment
+      variable. To find your keys, check https://archive.org/account/s3.php.
+    - ``s3_secret_key`` The S3-like secret key to log into the Internet Archive
+      with. This can also be set via the `IAS3_ACCESS_KEY` environment
+      variable. To find your keys, check https://archive.org/account/s3.php.
+    - ``capture_all`` If true, capture the URL regardless of the status code.
+      By default, only URLs with a 2xx status are captured.
+    - ``capture_outlinks`` If true, also capture URLs linked to from
+      ``target_url``. This works for HTML, PDF, and JSON/RSS feeds.
+    - ``capture_screenshot`` If true, capture a full page screenshot in PNG
+      format.
+    - ``force_get`` If true, do not use a web browser to capture
+      ``target_url``. By default, Save Page Now will determine whether to use a
+      browser automatically.
+    - ``skip_first_archive`` If true, do not check whether this was the first
+      capture of ``target_url``. This can speed up captures.
+    - ``if_not_archived_within`` Only capture ``target_url`` if it was not
+      already captured within this timeframe. If you do not set this, a default
+      value will be applied by archive.org's servers. This can be a timedelta
+      object, a number (of seconds), or a string with a format like
+      ``"3d 5h 20m"`` (3 days, 5 hours, and 20 minutes). If
+      ``capture_outlinks`` is true, this may also be a sequence of 2 of any of
+      the above types, where the first item represents the timeframe for
+      ``target_url`` and the second item represents the timeframe for outlinks.
+    - ``outlinks_availability`` If true, include the timestamp of the last
+        capture for all outlinks in the result.
+    - ``email_result`` If true send en e-mail report of the results to the
+      user whose credentials were used for this capture.
+    - ``js_behavior_timeout`` Limit JavaScript execution to this many seconds
+      after page load. Setting this to ``0`` prevents JavaScript execution
+      entirely.
+    - ``capture_cookie`` Cookie values to set when capturing ``target_url``.
+    - ``target_username`` Use this username in the page's login forms when
+      capturing it.
+    - ``target_password`` Use this password in the page's login forms when
+      capturing it.
+    - ``status_interval`` Check for results every N seconds.
+    """
+    if not isinstance(status_interval, (float, int)):
+        raise TypeError('status_interval must be a number >= 0')
+    elif status_interval < 0:
+        raise ValueError('status_interval must be >= 0')
+
+    job_info = queue_capture_v2(
+        target_url,
+        user_agent=user_agent,
+        # Set `accept_cache` so we can continue execution and return cached
+        # results with the error.
+        accept_cache=True,
+        s3_access_key=s3_access_key,
+        s3_secret_key=s3_secret_key,
+        capture_all=capture_all,
+        capture_outlinks=capture_outlinks,
+        capture_screenshot=capture_screenshot,
+        force_get=force_get,
+        skip_first_archive=skip_first_archive,
+        if_not_archived_within=if_not_archived_within,
+        outlinks_availability=outlinks_availability,
+        email_result=email_result,
+        js_behavior_timeout=js_behavior_timeout,
+        capture_cookie=capture_cookie,
+        target_username=target_username,
+        target_password=target_password
+    )
+    while True:
+        status = get_status_v2(
+            job_info['job_id'],
+            user_agent=user_agent,
+            s3_access_key=s3_access_key,
+            s3_secret_key=s3_secret_key
+        )
+        if status['status'] == 'pending':
+            time.sleep(status_interval)
+            continue
+        elif not accept_cache and 'message' in job_info:
+            archive_url = f'https://web.archive.org/web/{status["timestamp"]}/{status["original_url"]}'
+            error = CachedPage(f'archive.org returned a cache of this page: {archive_url}')
+            error.job_id = status['job_id']
+            error.url = job_info['url']
+            error.result = status
+            raise error
+        else:
+            return status
+
+
+def get_authorization(s3_access_key, s3_secret_key):
+    """
+    Get an authorization header string for the currently configured "S3-like"
+    keys. This will read environment variables if the parameters are ``None``.
+    """
+    if not s3_access_key:
+        s3_access_key = getenv('IAS3_ACCESS_KEY')
+    if not s3_secret_key:
+        s3_secret_key = getenv('IAS3_SECRET_KEY')
+    if not s3_access_key or not s3_secret_key:
+        raise TypeError(
+            'You must set the `s3_access_key` and `s3_secret_key` parameters '
+            'or the `IAS3_ACCESS_KEY` and `IAS3_SECRET_KEY` environment '
+            'variables to use the v2 API'
+        )
+
+    return f'LOW {s3_access_key}:{s3_secret_key}'
+
+
+def parse_api_error(data):
+    """
+    Parse an error response from the API and return an exception object that
+    represents it.
+    """
+    bad_arguments = (
+        'error:invalid-url-syntax',
+        'error:invalid-url',
+        'error:invalid-host-resolution',
+    )
+
+    # TODO: Consider whether any of these deserve special types
+    # other_errors = (
+    #     'error:too-many-daily-captures',
+    #     'error:invalid-server-response',
+    #     'error:user-session-limit',
+    #     'error:soft-time-limit-exceeded',
+    #     'error:proxy-error',
+    #     'error:browsing-timeout',
+    #     'error:no-browsers-available',
+    #     'error:redis-error',
+    #     'error:capture-location-error',
+    #     'error:gateway-timeout',
+    #     'error:no-access',
+    #     'error:not-found',
+    #     'error:celery',
+    #     'error:filesize-limit',
+    #     'error:ftp-access-denied',
+    #     'error:read-timeout',
+    #     'error:protocol-error',
+    #     'error:too-many-redirects',
+    #     'error:too-many-requests',
+    #     'error:not-implemented',
+    #     'error:bad-gateway',
+    #     'error:service-unavailable',
+    #     'error:http-version-not-supported',
+    #     'error:network-authentication-required',
+    # )
+
+    error_name = data['status_ext']
+    if error_name in bad_arguments:
+        error = ValueError(data['message'])
+    elif error_name == 'error:blocked-url':
+        error = BlockedUrl(data['message'])
+    else:
+        error = WaybackRuntimeError(data['message'])
+
+    # Attach additional details to the error.
+    error.exception = data.get('exception')
+    error.status_ext = data.get('status_ext')
+    error.job_id = data.get('job_id')
+
+    return error
 
 
 @click.command()

--- a/savepagenow/exceptions.py
+++ b/savepagenow/exceptions.py
@@ -27,6 +27,7 @@ class BlockedUrl(WaybackRuntimeError):
     """
     pass
 
+
 class BlockedByRobots(BlockedUrl):
     """
     This error is raised when archive.org has been blocked by the site's

--- a/savepagenow/exceptions.py
+++ b/savepagenow/exceptions.py
@@ -20,8 +20,16 @@ class WaybackRuntimeError(Exception):
     pass
 
 
-class BlockedByRobots(WaybackRuntimeError):
+class BlockedUrl(WaybackRuntimeError):
     """
-    This error is raised when archive.org has been blocked by the site's robots.txt access control instructions.
+    This error is raised when the requested URL is blocked and cannot be
+    captured.
+    """
+    pass
+
+class BlockedByRobots(BlockedUrl):
+    """
+    This error is raised when archive.org has been blocked by the site's
+    robots.txt access control instructions.
     """
     pass

--- a/test.py
+++ b/test.py
@@ -17,6 +17,14 @@ class CaptureTest(unittest.TestCase):
         archive_url, c = savepagenow.capture_or_cache(url)
         self.assertTrue(archive_url.startswith("https://web.archive.org/"))
 
+    def test_capture_v2(self):
+        """
+        Test the basic function of retriving a URL from Wayback using the API.
+        """
+        url = "https://www.latimes.com/california"
+        data = savepagenow.capture_v2(url, accept_cache=True)
+        self.assertTrue(data['original_url'].startswith("https://www.latimes.com/"))
+
     # def test_robots_error(self):
     #     with self.assertRaises(savepagenow.BlockedByRobots):
     #         savepagenow.capture("http://www.archive.is/faq.html")


### PR DESCRIPTION
This is a first draft of support for the new(ish) v2 Save Page Now API, but it’s not really ready to merge. This could probably use some deeper thought on function naming, more detailed exception types, CLI support. I’d also appreciate some general feedback on the direction here.

**Background:** Save Page Now shipped v2 a little while ago, and it now has a proper API to use rather than just acting like a browser and requesting `https://web.archive.org/save/<url>`. It allows you to configure a number of useful features like cookies, login information, etc., but requires authentication. In this commit, I’ve added support for it as a separate `capture_v2()` function so as not to break existing users of this package who won’t have authentication configured. Official documentation can be found at: https://docs.google.com/document/d/1Nsv52MvSjbLb2PCpHlat0gkzw0EvtSgpKHu4mk0MnrA (Yes, this is the official link.)

Authorization is done through the Internet Archive’s “S3-like” keys (find yours at https://archive.org/account/s3.php). You can set them as function arguments or as the environment variables `IAS3_ACCESS_KEY` and `IAS3_SECRET_KEY`.

The API is based around a queue: you make one call to enqueue a capture job, then poll the status endpoint until the job has completed. I’ve broken the implementation up into one function for each of those calls plus a wrapper than handles the whole process. A user might want access to the lower-level functions in order to start parallel captures.

Some notes and questions:

- I’ve used a few Python 3.6+ features since it looks like that’s the minimum requirements based on the classifiers in `setup.py` and the `Pipfile` says 3.8+. Let me know if this actually needs to support older Python versions.

- I added a new `BlockedUrl` exception since the API returns information about URL blocking that isn’t necessarily caused by `robots.txt` files.

- There is a lot of detailed error information in the API, so it seems like we could add some more detailed exception types. At the very least, it might be useful to differentiate errors contacting the requested URL vs. errors on Wayback’s part.

- I added some more contextual information to the exceptions in an ad-hoc way, but it would probably be better to modify the exception classes to directly support that info.

- I’m not sure the function names I’ve chosen here are great. First off, v2 is not really a differentiator — `capture()` is also using v2, but through the browser interface instead of the API. `queue_capture_*` and `get_status_*` also don’t feel especially cohesive to me.

- I’ve used the same parameter names and default values as the API. Not sure if that feels ideal. I think it might be a good idea to require everything but `target_url` to be a keyword argument.

- Credential arguments come after `user_agent` and `accept_cache` to match the existing API. it feels a little awkward to place them there, though, since they are critical to set. Maybe I should have put them at the end.

- I haven’t yet added CLI support. Should it just automatically use the API if S3-like keys are set, or should someone have to explicitly opt-in via a CLI option?

Any other feedback is very welcome!

Fixes #22.