### PR TITLE
Update documentation to reflect new rate limit for requests

### DIFF
--- a/docs/python.md
+++ b/docs/python.md
@@ -23,9 +23,9 @@ print(archive_url)
 
 ### Authentication
 
-By default, savepagenow sends anonymous requests, which are limited to four captures per minute.
+By default, savepagenow sends anonymous requests, which are limited to 3 captures per minute.
 
-Authenticated requests are allowed 12 captures per minute. To take advantage of this, you must register an account with [archive.org](https://archive.org/account/login.createaccount.php) and
+Authenticated requests are allowed 6 captures per minute. To take advantage of this, you must register an account with [archive.org](https://archive.org/account/login.createaccount.php) and
 set your [API credentials](https://archive.org/account/s3.php) to the local environment variables ``SAVEPAGENOW_ACCESS_KEY`` and ``SAVEPAGENOW_SECRET_KEY``.
 
 Then you can run `capture()` with the authenticate flag set to true like so:

--- a/docs/python.md
+++ b/docs/python.md
@@ -23,7 +23,7 @@ print(archive_url)
 
 ### Authentication
 
-By default, savepagenow sends anonymous requests, which are limited to 3 captures per minute.
+By default, savepagenow sends anonymous requests, which are limited to three captures per minute.
 
 Authenticated requests are allowed 6 captures per minute. To take advantage of this, you must register an account with [archive.org](https://archive.org/account/login.createaccount.php) and
 set your [API credentials](https://archive.org/account/s3.php) to the local environment variables ``SAVEPAGENOW_ACCESS_KEY`` and ``SAVEPAGENOW_SECRET_KEY``.


### PR DESCRIPTION
Was originally alerted to this by user overcast07 in this thread: https://github.com/palewire/savepagenow/pull/45 Confirmed with the Internet Archive team the new rate limit